### PR TITLE
RTTUI: Client side timestamps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,6 +163,7 @@ name = "cargo-embed"
 version = "0.6.0"
 dependencies = [
  "cargo-project",
+ "chrono",
  "colored",
  "config",
  "env_logger",
@@ -213,6 +214,17 @@ name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "chrono"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2"
+dependencies = [
+ "num-integer",
+ "num-traits 0.2.11",
+ "time",
+]
 
 [[package]]
 name = "clap"
@@ -916,6 +928,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-integer"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba"
+dependencies = [
+ "autocfg",
+ "num-traits 0.2.11",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1533,6 +1555,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "time"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
+dependencies = [
+ "libc",
+ "redox_syscall",
+ "winapi 0.3.8",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ gdb-server = { version = "0.6.0" }
 serde = { version = "1.0", features = ["derive"] }
 config = { version = "0.9.0", features = ["toml", "json", "yaml"], default-features = false }
 probe-rs-rtt = { version = "0.1.0" }
+chrono = "0.4"
 
 goblin = "0.2.0"
 tui = "0.8.0"

--- a/src/config/default.toml
+++ b/src/config/default.toml
@@ -35,6 +35,8 @@ channels = [
 ]
 # The duration in ms for which the logger should retry to attach to RTT.
 timeout = 3000
+# Whether timestamps in the RTTUI are enabled
+show_timestamps = true
 
 [gdb]
 # Whether or not a GDB server should be opened after flashing.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -49,6 +49,8 @@ pub struct Rtt {
     pub channels: Vec<ChannelConfig>,
     /// Connection timeout in ms.
     pub timeout: usize,
+    /// Whether to show timestamps in RTTUI
+    pub show_timestamps: bool,
 }
 
 /// The gdb config struct holding all the possible gdb options.

--- a/src/rttui/app.rs
+++ b/src/rttui/app.rs
@@ -30,11 +30,10 @@ pub struct App {
 }
 
 fn pull_channel<C: RttChannel>(channels: &mut Vec<C>, n: usize) -> Option<C> {
-    let c =
-        channels
-            .iter()
-            .enumerate()
-            .find_map(|(i, c)| if c.number() == n { Some(i) } else { None });
+    let c = channels
+        .iter()
+        .enumerate()
+        .find_map(|(i, c)| if c.number() == n { Some(i) } else { None });
 
     c.map(|c| channels.remove(c))
 }
@@ -59,6 +58,7 @@ impl App {
                         .down
                         .and_then(|down| pull_channel(&mut down_channels, down)),
                     channel.name.clone(),
+                    CONFIG.rtt.show_timestamps,
                 ))
             }
         } else {
@@ -68,11 +68,17 @@ impl App {
                     Some(channel),
                     pull_channel(&mut down_channels, number),
                     None,
+                    CONFIG.rtt.show_timestamps,
                 ));
             }
 
             for channel in down_channels {
-                tabs.push(ChannelState::new(None, Some(channel), None));
+                tabs.push(ChannelState::new(
+                    None,
+                    Some(channel),
+                    None,
+                    CONFIG.rtt.show_timestamps,
+                ));
             }
         }
 

--- a/src/rttui/channel.rs
+++ b/src/rttui/channel.rs
@@ -103,19 +103,19 @@ impl ChannelState {
             return;
         }
 
-        // First, convert the incomming bytes to UTF8.
-        let mut incomming = String::from_utf8_lossy(&self.rtt_buffer[..count]).to_string();
+        // First, convert the incoming bytes to UTF8.
+        let mut incoming = String::from_utf8_lossy(&self.rtt_buffer[..count]).to_string();
 
         // Then pop the last stored line from our line buffer if possible and append our new line.
         if !self.last_line_done {
             if let Some(last_line) = self.messages.pop() {
-                incomming = last_line + &incomming;
+                incoming = last_line + &incoming;
             }
         }
-        self.last_line_done = incomming.chars().last().unwrap() == '\n';
+        self.last_line_done = incoming.chars().last().unwrap() == '\n';
 
         // Then split the entire new contents.
-        let split = incomming.split_terminator('\n');
+        let split = incoming.split_terminator('\n');
 
         // Then add all the splits to the linebuffer.
         self.messages.extend(split.clone().map(|s| s.to_string()));

--- a/src/rttui/channel.rs
+++ b/src/rttui/channel.rs
@@ -1,3 +1,4 @@
+use chrono::{Local, SecondsFormat};
 use probe_rs_rtt::{DownChannel, UpChannel};
 
 #[derive(Debug, serde::Serialize, serde::Deserialize, Clone)]
@@ -16,6 +17,7 @@ pub struct ChannelState {
     input: String,
     scroll_offset: usize,
     rtt_buffer: [u8; 1024],
+    show_timestamps: bool,
 }
 
 impl ChannelState {
@@ -23,6 +25,7 @@ impl ChannelState {
         up_channel: Option<UpChannel>,
         down_channel: Option<DownChannel>,
         name: Option<String>,
+        show_timestamps: bool,
     ) -> Self {
         let name = name
             .clone()
@@ -37,10 +40,11 @@ impl ChannelState {
             down_channel,
             name,
             messages: Vec::new(),
-            last_line_done: false,
+            last_line_done: true,
             input: String::new(),
             scroll_offset: 0,
             rtt_buffer: [0u8; 1024],
+            show_timestamps,
         }
     }
 
@@ -86,6 +90,8 @@ impl ChannelState {
     ///
     /// Processes all the new data and adds it to the linebuffer of the respective channel.
     pub fn poll_rtt(&mut self) {
+        let now = Local::now();
+
         // TODO: Proper error handling.
         let count = if let Some(channel) = self.up_channel.as_mut() {
             match channel.read(self.rtt_buffer.as_mut()) {
@@ -107,7 +113,8 @@ impl ChannelState {
         let mut incoming = String::from_utf8_lossy(&self.rtt_buffer[..count]).to_string();
 
         // Then pop the last stored line from our line buffer if possible and append our new line.
-        if !self.last_line_done {
+        let last_line_done = self.last_line_done;
+        if !last_line_done {
             if let Some(last_line) = self.messages.pop() {
                 incoming = last_line + &incoming;
             }
@@ -115,13 +122,16 @@ impl ChannelState {
         self.last_line_done = incoming.chars().last().unwrap() == '\n';
 
         // Then split the entire new contents.
-        let split = incoming.split_terminator('\n');
-
-        // Then add all the splits to the linebuffer.
-        self.messages.extend(split.clone().map(|s| s.to_string()));
-
-        if self.scroll_offset != 0 {
-            self.scroll_offset += split.count();
+        for (i, line) in incoming.split_terminator('\n').enumerate() {
+            if self.show_timestamps && (last_line_done || i > 0) {
+                let ts = now.to_rfc3339_opts(SecondsFormat::Millis, true);
+                self.messages.push(format!("[{}] {}", ts, line));
+            } else {
+                self.messages.push(line.to_string());
+            }
+            if self.scroll_offset != 0 {
+                self.scroll_offset += 1;
+            }
         }
     }
 

--- a/src/rttui/channel.rs
+++ b/src/rttui/channel.rs
@@ -1,4 +1,4 @@
-use chrono::{Local, SecondsFormat};
+use chrono::Local;
 use probe_rs_rtt::{DownChannel, UpChannel};
 
 #[derive(Debug, serde::Serialize, serde::Deserialize, Clone)]
@@ -124,8 +124,8 @@ impl ChannelState {
         // Then split the entire new contents.
         for (i, line) in incoming.split_terminator('\n').enumerate() {
             if self.show_timestamps && (last_line_done || i > 0) {
-                let ts = now.to_rfc3339_opts(SecondsFormat::Millis, true);
-                self.messages.push(format!("[{}] {}", ts, line));
+                let ts = now.format("%H:%M:%S%.3f");
+                self.messages.push(format!("{} {}", ts, line));
             } else {
                 self.messages.push(line.to_string());
             }


### PR DESCRIPTION
Optional client-side timestamps:

![timestamp](https://user-images.githubusercontent.com/105168/79700055-78fef680-8293-11ea-886a-7f841223db14.png)

Unfortunately this requires Chrono, because std can't really do stuff like proper date formatting.

Open question: These timestamps are not very precise, they depend on the polling interval and may be delayed by other tasks. Should we remove milliseconds from the dates to avoid "faking precision", or are they still useful?