### PR TITLE
Allow overriding logging config with RUST_LOG

### DIFF
--- a/src/logging.rs
+++ b/src/logging.rs
@@ -52,8 +52,8 @@ fn colored_level(level: Level) -> ColoredString {
 ///
 /// There are two sources of log level configuration:
 ///
-/// - The config file can define the default log level through `general.log_level`
-/// - The user can set the `RUST_LOG` env var, which overrides the log level from the config
+/// - The config file can define the default log level through `general.log_level`.
+/// - The user can set the `RUST_LOG` env var, which overrides the log level from the config.
 ///
 /// The config file only accepts a log level, while the `RUST_LOG` variable
 /// supports the full `env_logger` syntax, including filtering by crate and


### PR DESCRIPTION
Previously the `RUST_LOG` env var would always get overridden by the default config and was thus useless.

Now overriding the config seems to work nicely!

![2020-06-26-220624_1587x588_scrot](https://user-images.githubusercontent.com/105168/85896719-4a544d80-b7f9-11ea-9f8d-165b3aa5bbfa.png)
