### PR TITLE
Small debug message improvement; formatting of multi-line errors

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -421,7 +421,7 @@ fn main_try() -> Result<()> {
         let t = std::time::Instant::now();
         let mut error = None;
 
-        let mut i = 0;
+        let mut i = 1;
 
         while (t.elapsed().as_millis() as usize) < config.rtt.timeout {
             log::info!("Initializing RTT (attempt {})...", i);

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use std::{
     env,
     fs::File,
     io::Write,
-    panic,
+    iter, panic,
     path::{Path, PathBuf},
     process::{self, Command, Stdio},
     sync::{Arc, Mutex},
@@ -69,8 +69,28 @@ fn main() {
             // to access stderr during shutdown.
             //
             // We ignore the errors, not much we can do anyway.
+
             let mut stderr = std::io::stderr();
-            let _ = writeln!(stderr, "       {} {:?}", "Error".red().bold(), e);
+
+            let first_line_prefix = "Error".red().bold();
+            let other_line_prefix: String = iter::repeat(" ")
+                .take(first_line_prefix.chars().count())
+                .collect();
+
+            let error = format!("{:?}", e);
+
+            for (i, line) in error.lines().enumerate() {
+                let _ = write!(stderr, "       ");
+
+                if i == 0 {
+                    let _ = write!(stderr, "{}", first_line_prefix);
+                } else {
+                    let _ = write!(stderr, "{}", other_line_prefix);
+                };
+
+                let _ = writeln!(stderr, " {}", line);
+            }
+
             let _ = stderr.flush();
 
             process::exit(1);


### PR DESCRIPTION
Here's what the multi-line formatting looks like:
![multi-line-errors](https://user-images.githubusercontent.com/85732/86456877-0eeadf00-bd23-11ea-89f5-48361461470f.png)
