### PR TITLE
Reset without flashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- The config supports a new section called `reset`. It controls whether the target is reset. Default config:
+
+    ```toml
+    [default.reset]
+    # Whether or not the target should be reset.
+    # When flashing is enabled as well, the target will be reset after flashing.
+    enabled = true
+    # Whether or not the target should be halted after reset.
+    halt_afterwards = false
+    ```
+
+  This way, you can add a `cargo embed` target that allows resetting and
+  optionally halting without flashing. Useful for debugging.
+
 ### Changed
+
+- The config option `flashing.halt_afterwards` has moved to `reset.halt_afterwards`
 
 ### Fixed
 

--- a/src/config/default.toml
+++ b/src/config/default.toml
@@ -13,13 +13,21 @@ protocol = "Swd"
 [default.flashing]
 # Whether or not the target should be flashed.
 enabled = true
-# Whether or not the target should be halted after flashing.
+# Whether or not the target should be halted after reset.
+# DEPRECATED, moved to reset section
 halt_afterwards = false
 # Whether or not bytes erased but not rewritten with data from the ELF
 # should be restored with their contents before erasing.
 restore_unwritten_bytes = false
 # The path where an SVG of the assembled flash layout should be written to.
 # flash_layout_output_path = "out.svg"
+
+[default.reset]
+# Whether or not the target should be reset.
+# When flashing is enabled as well, the target will be reset after flashing.
+enabled = true
+# Whether or not the target should be halted after reset.
+halt_afterwards = false
 
 [default.general]
 # The chip name of the chip to be debugged.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -14,6 +14,7 @@ pub struct Configs(HashMap<String, Config>);
 pub struct Config {
     pub general: General,
     pub flashing: Flashing,
+    pub reset: Reset,
     pub probe: Probe,
     pub rtt: Rtt,
     pub gdb: Gdb,
@@ -33,9 +34,20 @@ pub struct Probe {
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Flashing {
     pub enabled: bool,
+    #[deprecated(
+        since = "0.9.0",
+        note = "The 'halt_afterwards' key has moved to the 'reset' section"
+    )]
     pub halt_afterwards: bool,
     pub restore_unwritten_bytes: bool,
     pub flash_layout_output_path: Option<String>,
+}
+
+/// The reset config struct holding all the possible reset options.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Reset {
+    pub enabled: bool,
+    pub halt_afterwards: bool,
 }
 
 /// The general config struct holding all the possible general options.

--- a/src/main.rs
+++ b/src/main.rs
@@ -190,9 +190,10 @@ fn main_try() -> Result<()> {
         )
         .map_err(|e| anyhow!("Couldn't get artifact path: {}", e))?;
 
+    logging::println(format!("      {} {}", "Config".green().bold(), config_name));
     logging::println(format!(
-        "    {} {}",
-        "Flashing".green().bold(),
+        "      {} {}",
+        "Target".green().bold(),
         path.display()
     ));
 
@@ -402,7 +403,7 @@ fn main_try() -> Result<()> {
         // Stop timer.
         let elapsed = instant.elapsed();
         logging::println(format!(
-            "    {} in {}s",
+            "    {} flashing in {}s",
             "Finished".green().bold(),
             elapsed.as_millis() as f32 / 1000.0,
         ));
@@ -413,7 +414,10 @@ fn main_try() -> Result<()> {
         let halt_timeout = Duration::from_millis(500);
         #[allow(deprecated)] // Remove in 0.10
         if config.flashing.halt_afterwards {
-            logging::eprintln("Warning: The 'flashing.halt_afterwards' option in the config has moved to the 'reset' section");
+            logging::eprintln(format!(
+                "     {} The 'flashing.halt_afterwards' option in the config has moved to the 'reset' section",
+                "Warning".yellow().bold()
+            ));
             core.reset_and_halt(halt_timeout)?;
         } else if config.reset.halt_afterwards {
             core.reset_and_halt(halt_timeout)?;
@@ -505,6 +509,12 @@ fn main_try() -> Result<()> {
             return Err(error);
         }
     }
+
+    logging::println(format!(
+        "        {} processing config {}",
+        "Done".green().bold(),
+        config_name
+    ));
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -406,10 +406,17 @@ fn main_try() -> Result<()> {
             "Finished".green().bold(),
             elapsed.as_millis() as f32 / 1000.0,
         ));
+    }
 
+    if config.reset.enabled {
         let mut core = session.core(0)?;
+        let halt_timeout = Duration::from_millis(500);
+        #[allow(deprecated)] // Remove in 0.10
         if config.flashing.halt_afterwards {
-            core.reset_and_halt(Duration::from_millis(500))?;
+            logging::eprintln("Warning: The 'flashing.halt_afterwards' option in the config has moved to the 'reset' section");
+            core.reset_and_halt(halt_timeout)?;
+        } else if config.reset.halt_afterwards {
+            core.reset_and_halt(halt_timeout)?;
         } else {
             core.reset()?;
         }


### PR DESCRIPTION
Allow resetting without flashing.

The 0.8 config should still work, but the `halt_afterwards` flashing config is deprecated. It belongs in the reset section. In 0.10 we can remove it.

Also note that while running, my JLink fails to reset the target (but it works with JLinkExe). That seems to be an unrelated bug (which should now be easier to reproduce).