### PR TITLE
fix suggested solution when multiple probes are detected

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -189,7 +189,9 @@ fn main_try() -> Result<()> {
             // a single probe detected.
             let list = Probe::list_all();
             if list.len() > 1 {
-                return Err(anyhow!("More than a single probe detected. Use the --probe-selector argument to select which probe to use."));
+                return Err(anyhow!("More than a single probe was detected. Use the [default.probe] config attribute \
+                                    (in your Embed.toml) to select which probe to use. \
+                                    For usage examples see https://github.com/probe-rs/cargo-embed/blob/master/src/config/default.toml ."));
             }
 
             Probe::open(


### PR DESCRIPTION
closes https://github.com/probe-rs/cargo-embed/issues/33

I could not find the selector attribute so its either too late for me or its not there ;)

these should be the ones wanted though?
```toml
# USB vendor ID
# usb_vid = "1337"
# USB product ID
# usb_pid = "1337"
```