### PR TITLE
add git commit hash to version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,9 +159,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "base64"
-version = "0.12.3"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bitfield"
@@ -228,6 +228,7 @@ dependencies = [
  "derivative",
  "env_logger",
  "gdb-server",
+ "git-version",
  "goblin",
  "indicatif",
  "lazy_static",
@@ -244,9 +245,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89fec17b16f1ac67908af82e47d0a90a7afd0e1827b181cd77504323d3263d35"
+checksum = "d5a5f7b42f606b7f23674f6f4d877628350682bc40687d3fae65679a58d55345"
 dependencies = [
  "semver",
  "serde",
@@ -645,13 +646,35 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaf91faf136cb47367fa430cd46e37a788775e7fa104f8b4bcb3861dc389b724"
+checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
 dependencies = [
  "fallible-iterator",
  "indexmap",
  "stable_deref_trait",
+]
+
+[[package]]
+name = "git-version"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94918e83f1e01dedc2e361d00ce9487b14c58c7f40bab148026fa39d42cb41e2"
+dependencies = [
+ "git-version-macro",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "git-version-macro"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34a97a52fdee1870a34fa6e4b77570cba531b27d1838874fef4429a791a3d657"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -974,9 +997,9 @@ checksum = "17b02fc0ff9a9e4b35b3342880f48e896ebf69f2967921fe8646bf5b7125956a"
 
 [[package]]
 name = "object"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37fd5004feb2ce328a52b0b3d01dbf4ffff72583493900ed15f22d4111c51693"
+checksum = "8d3b63360ec3cb337817c2dbd47ab4a0f170d285d8e5a2064600f3def1402397"
 dependencies = [
  "flate2",
  "wasmparser",
@@ -1022,6 +1045,15 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "winapi",
+]
+
+[[package]]
+name = "pest"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+dependencies = [
+ "ucd-trie",
 ]
 
 [[package]]
@@ -1083,7 +1115,7 @@ dependencies = [
 [[package]]
 name = "probe-rs"
 version = "0.9.0"
-source = "git+https://github.com/probe-rs/probe-rs#8bd8e6e49d2d6246088f57c6530616890f106e81"
+source = "git+https://github.com/probe-rs/probe-rs#21b26ad020cf07cd797593c503a7c8f3a8530fca"
 dependencies = [
  "anyhow",
  "base64",
@@ -1138,7 +1170,7 @@ dependencies = [
 [[package]]
 name = "probe-rs-t2rust"
 version = "0.6.0"
-source = "git+https://github.com/probe-rs/probe-rs#8bd8e6e49d2d6246088f57c6530616890f106e81"
+source = "git+https://github.com/probe-rs/probe-rs#21b26ad020cf07cd797593c503a7c8f3a8530fca"
 dependencies = [
  "base64",
  "proc-macro2",
@@ -1293,9 +1325,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "394cec28fa623e00903caf7ba4fa6fb9a0e260280bb8cdbbba029611108a0190"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
 dependencies = [
  "semver-parser",
  "serde",
@@ -1303,9 +1335,12 @@ dependencies = [
 
 [[package]]
 name = "semver-parser"
-version = "0.7.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+checksum = "42ef146c2ad5e5f4b037cd6ce2ebb775401729b19a82040c1beac9d36c7d1428"
+dependencies = [
+ "pest",
+]
 
 [[package]]
 name = "serde"
@@ -1329,9 +1364,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.57"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "164eacbdb13512ec2745fb09d51fd5b22b0d65ed294a1dcf7285a360c80a675c"
+checksum = "dcac07dbffa1c65e7f816ab9eba78eb142c6d44410f4eeba1e26e4f5dfa56b95"
 dependencies = [
  "itoa",
  "ryu",
@@ -1578,6 +1613,12 @@ dependencies = [
  "unicode-segmentation",
  "unicode-width",
 ]
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicode-segmentation"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ gdb-server = { version = "0.9.0", git = "https://github.com/probe-rs/probe-rs"  
 probe-rs-cli-util = { version = "0.9.0", git = "https://github.com/probe-rs/probe-rs" }
 
 structopt = "0.3.18"
+git-version = "0.3.4"
 indicatif = "0.15.0"
 env_logger = "0.7.1"
 log = { version = "0.4.0", features = ["serde"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,8 +28,14 @@ use probe_rs::{
 use probe_rs_cli_util::build_artifact;
 use probe_rs_rtt::{Rtt, ScanRegion};
 
+const CARGO_NAME: &'static str = env!("CARGO_PKG_NAME");
+const CARGO_VERSION: &'static str = env!("CARGO_PKG_VERSION");
+const GIT_VERSION: &'static str = git_version::git_version!();
+
 #[derive(Debug, StructOpt)]
 struct Opt {
+    #[structopt(short = "V", long = "version")]
+    pub version: bool,
     #[structopt(name = "config")]
     config: Option<String>,
     #[structopt(name = "chip", long = "chip")]
@@ -119,6 +125,14 @@ fn main_try() -> Result<()> {
 
     // Get commandline options.
     let opt = Opt::from_iter(&args);
+
+    if opt.version {
+        println!(
+            "{} {}\ngit commit: {}",
+            CARGO_NAME, CARGO_VERSION, GIT_VERSION
+        );
+        return Ok(());
+    }
 
     let work_dir = std::env::current_dir()?;
 


### PR DESCRIPTION
as discussed on matrix this may be helpful for user bug reports

I could not find a way to format the string at compile time in which
case I could have used something like:
`#[structopt(version = git_version::git_version!() + .... )]`

output:
```
$ cargo run - --version
cargo-embed 0.9.1
git commit: baca8ba
```

If you want to do the cargo update stuff separately I can also adjust after thats done.

Tested on macos only.