### PR TITLE
Do not call DisableMouseCapture, EnableMouseCapture is never called

### DIFF
--- a/src/rttui/app.rs
+++ b/src/rttui/app.rs
@@ -3,6 +3,7 @@ use crossterm::{
     event::{self, KeyCode},
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+    ExecutableCommand,
 };
 use probe_rs_rtt::RttChannel;
 use std::{fmt::write, path::PathBuf, sync::mpsc::RecvTimeoutError};
@@ -487,5 +488,5 @@ impl App {
 
 pub fn clean_up_terminal() {
     let _ = disable_raw_mode();
-    let _ = execute!(std::io::stdout(), LeaveAlternateScreen, DisableMouseCapture);
+    let _ = execute!(std::io::stdout(), LeaveAlternateScreen);
 }


### PR DESCRIPTION
When `DisableMouseCapture` is executed, this leads to a panic! on Windows because `EnableMouseCapture` is never called.
The `clean_up_terminal()` function is called in the panic handler, so this leads to a panic inside a panic, as described in #241.

This PR should fix #241.