### PR TITLE
Add missing dependency `libudev-dev` to README list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,6 @@ You may also need to remove old versions of libusb:
 > sudo apt remove libusb-dev
 ```
 
-
 #### Windows
 
 On Windows you can use [vcpkg](https://github.com/microsoft/vcpkg#quick-start-windows) to install the prerequisites:


### PR DESCRIPTION
Fixes https://github.com/probe-rs/cargo-embed/issues/325. I have encountered the same error while trying to install `cargo-embed` on a WSL installation of Ubuntu.